### PR TITLE
Add option for always show the submode even if noshowmode

### DIFF
--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -74,6 +74,10 @@ if !exists('g:submode_timeoutlen')
   let g:submode_timeoutlen = &timeoutlen
 endif
 
+if !exists('g:submode_always_show_submode')
+  let g:submode_always_show_submode = 0
+endif
+
 
 
 
@@ -401,7 +405,7 @@ endfunction
 
 
 function! s:on_executing_action(submode)  "{{{2
-  if s:original_showmode && s:may_override_showmode_p(mode())
+  if (s:original_showmode || g:submode_always_show_submode) && s:may_override_showmode_p(mode())
     echohl ModeMsg
     echo '-- Submode:' a:submode '--'
     echohl None
@@ -413,7 +417,7 @@ endfunction
 
 
 function! s:on_leaving_submode(submode)  "{{{2
-  if s:original_showmode && s:may_override_showmode_p(mode())
+  if (s:original_showmode || g:submode_always_show_submode) && s:may_override_showmode_p(mode())
     if s:insert_mode_p(mode())
       let cussor_position = getpos('.')
     endif

--- a/doc/submode.txt
+++ b/doc/submode.txt
@@ -225,6 +225,10 @@ g:submode_timeoutlen		number (default: same as 'timeoutlen')
 	If this variable is not defined, the value of 'timeoutlen' is used
 	instead.
 
+						*g:submode_always_show_submode*
+g:submode_always_show_submode		boolean (default: false)
+	Show always the submode you're in, even if 'noshowmode' is set.
+
 
 
 


### PR DESCRIPTION
Hi, I use powerline so showmode for me is pretty useless but I would like to see if and in what submode I'm in. With this little PR is now possible. The default behavior remain the original one. I wrote just one line in the docs since I'm not use to write vim help file, so let me know if I should add something and primarily if something is wrong in general.
