### PR TITLE
Little fix for bug in executing_on_action

### DIFF
--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -405,8 +405,9 @@ function! s:on_executing_action(submode)  "{{{2
     echohl ModeMsg
     echo '-- Submode:' a:submode '--'
     echohl None
+  else
+    return ''
   endif
-  return ''
 endfunction
 
 


### PR DESCRIPTION
So far s:on_executing_action always returns an empty string. When the showmode is active, this however causes a bug for  mappings that include a carriage return, in pseudocode:

``` vimscript
   # a mapping created by submode definition function
   nmap xx :call HelperFunction()<cr>
```

While everything is executed correctly (i.e. the HelperFunction got called), the cursor will hang in showmode-line, right after the highlighted string, that indicates the current submode. There's no way to return the cursor to the buffer other than leaving the submode then.

If we don't return '' when the submode is echoed, everything's fine again.
