### PR TITLE
Exposes current submode

### DIFF
--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -168,6 +168,9 @@ endfunction
 
 
 
+function! submode#active_submode() "{{{2
+  return get(s:, 'active_submode', '')
+endfunction
 
 
 
@@ -411,7 +414,7 @@ endfunction
 
 
 function! s:on_entering_submode(submode)  "{{{2
-  let g:submode_active_submode = a:submode
+  let s:active_submode = a:submode
   call s:set_up_options()
   return ''
 endfunction
@@ -452,7 +455,7 @@ function! s:on_leaving_submode(submode)  "{{{2
     call getchar()
   endif
   call s:restore_options()
-  let g:submode_active_submode = ''
+  let s:active_submode = ''
   return ''
 endfunction
 

--- a/doc/submode.txt
+++ b/doc/submode.txt
@@ -96,6 +96,11 @@ COMMANDS					*submode-commands*
 ------------------------------------------------------------------------------
 FUNCTIONS					*submode-functions*
 
+						*submode#active_submode()*
+submode#active_submode()
+		        Returns the name of the currently active submode
+                        or '' if no submode is running.
+
 						*submode#enter_with()*
 submode#enter_with({submode}, {modes}, {options}, {lhs}, [{rhs}])
 			Define a key mapping to enter the {submode} from

--- a/plugin/submode.vim
+++ b/plugin/submode.vim
@@ -2,5 +2,4 @@ if exists("g:loaded_submode")
   finish
 endif
 
-let g:submode_active_submode = ''
 let g:loaded_submode = 1


### PR DESCRIPTION
In response to #10 I actually did write an airline-extension for submode now. (will later create a PR for it there as well)

For that submode needs to expose itself a bit: airline (and probably other plugins in the future?) needs to know that submode is available and what a potentially active submode is called.

Are you fine with that?
