### PR TITLE
Minor aesthetic fix

### DIFF
--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -221,7 +221,7 @@ function! s:define_entering_mapping(submode, mode, options, lhs, rhs)  "{{{2
   \       s:named_key_prefix(a:submode)
   \       s:named_key_leave(a:submode)
   execute s:map_command(a:mode, '')
-  \       s:map_options('')
+  \       s:map_options('s')
   \       s:named_key_leave(a:submode)
   \       printf('%s<SID>on_leaving_submode(%s)<Return>',
   \              a:mode =~# '[ic]' ? '<C-r>=' : '@=',


### PR DESCRIPTION
When the submode is not shown, the last thing you see from a submode upon leaving is a message of its last expression evaluated => `=<SNR>131_on_leaving_submode('my_submode')`
This has a little debuggy feel for and clutters up the message line, imo it can safely be silenced. This could be arguably made optional, personally I would just disable it and be done with it.
