### PR TITLE
Submode Undo/Redo feature

### DIFF
--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -424,6 +424,8 @@ endfunction
 
 function! s:on_entering_submode(submode)  "{{{2
   call s:set_up_options(a:submode)
+  let s:submode_undo_changenr = changenr()
+  let s:has_changes = 1
   return ''
 endfunction
 
@@ -541,6 +543,29 @@ endfunction
 
 
 
+
+" Utility  "{{{1
+function! UndoLastSubmodeActions()
+  " Undo until submode's first modification
+  if s:has_changes
+    execute ':undo ' s:submode_undo_changenr
+    " Undo one more time through main undo branch
+    execute 'normal! u'
+    let s:submode_redo_changenr = changenr()
+    let s:has_changes = 0
+  endif
+endfunction
+
+
+
+
+function! RedoLastSubmodeActions()
+  " Undo until submode's first modification
+  if !s:has_changes
+    execute ':undo ' s:submode_redo_changenr
+    let s:has_changes = 1
+  endif
+endfunction
 
 
 

--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -555,29 +555,29 @@ endfunction
 
 " Utility  "{{{1
 function! s:UndoLastSubmodeActions()  "{{{2
-    if s:has_changes
-        " Current undo tree position for future possible redo action
-        let s:submode_redo_changenr = changenr()
-        " Undo until submode's first modification
-        execute ':undo ' s:submode_undo_changenr
-        " Undo one more time through main undo branch
-        execute 'normal! u'
-        let s:has_changes = 0
-        " To prevent calling the Redo function before calling Undo for
-        " any new submode entry
-        let s:is_redo_allowed = 1
-    endif
+  if s:has_changes
+    " Current undo tree position for future possible redo action
+    let s:submode_redo_changenr = changenr()
+    " Undo until submode's first modification
+    execute ':undo ' s:submode_undo_changenr
+    " Undo one more time through main undo branch
+    execute 'normal! u'
+    let s:has_changes = 0
+    " To prevent calling the Redo function before calling Undo for
+    " any new submode entry
+    let s:is_redo_allowed = 1
+  endif
 endfunction
 
 
 
 
 function! s:RedoLastSubmodeActions()  "{{{2
-    " Undo until submode's first modification
-    if s:is_redo_allowed
-        execute ':undo ' s:submode_redo_changenr
-        let s:has_changes = 1
-    endif
+  " Undo until submode's first modification
+  if s:is_redo_allowed
+    execute ':undo ' s:submode_redo_changenr
+    let s:has_changes = 1
+  endif
 endfunction
 
 

--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -123,7 +123,13 @@ let s:is_redo_allowed = 0
 
 command! -bar -nargs=0 SubmodeRestoreOptions  call submode#restore_options()
 
+" :SubmodeUndo  "{{{2
 
+command! SubmodeUndo call <SID>UndoLastSubmodeActions()
+
+" :SubmodeRedo  "{{{2
+
+command! SubmodeRedo call <SID>RedoLastSubmodeActions()
 
 
 function! submode#current()  "{{{2
@@ -548,7 +554,7 @@ endfunction
 
 
 " Utility  "{{{1
-function! s:UndoLastSubmodeActions()
+function! s:UndoLastSubmodeActions()  "{{{2
     if s:has_changes
         " Current undo tree position for future possible redo action
         let s:submode_redo_changenr = changenr()
@@ -566,19 +572,13 @@ endfunction
 
 
 
-function! s:RedoLastSubmodeActions()
+function! s:RedoLastSubmodeActions()  "{{{2
     " Undo until submode's first modification
     if s:is_redo_allowed
         execute ':undo ' s:submode_redo_changenr
         let s:has_changes = 1
     endif
 endfunction
-
-
-
-
-command! -range=% SubmodeUndo call <SID>UndoLastSubmodeActions()
-command! -range=% SubmodeRedo call <SID>RedoLastSubmodeActions()
 
 
 

--- a/doc/submode.txt
+++ b/doc/submode.txt
@@ -90,8 +90,11 @@ COMMANDS					*submode-commands*
 :SubmodeRestoreOptions				*:SubmodeRestoreOptions*
 			Ex command version of |submode#restore_options()|.
 
+:SubmodeUndo				*:SubmodeUndo*
+			Undo all modifications made in last submode execution.
 
-
+:SubmodeRedo				*:SubmodeRedo*
+			Redo all modifications made in last submode execution.
 
 ------------------------------------------------------------------------------
 FUNCTIONS					*submode-functions*

--- a/doc/submode.txt
+++ b/doc/submode.txt
@@ -274,6 +274,9 @@ LIMITATIONS ~
   ".........." is showed at the bottom right corner while a submode is active.
   This is to hide a part of internal key mappings for submode key mappings.
 
+- The Submode Undo/Redo feature works only with the last submode execution
+  and only with the current vim session (it does not keep a history).
+
 
 PROBLEMS ~
 
@@ -284,6 +287,9 @@ PROBLEMS ~
 
 - The current API to define submode key mappings is somewhat low-level.
   It might be useful to add |:map|-like commands for readability.
+
+- The Submode Undo/Redo feature may not work properly if a lot of
+  modifications are made after leaving submode.
 
 
 


### PR DESCRIPTION
Hello, I created a simple mechanism to undo and redo all the last modifications made in submode at once. I use this plugin for moving lines around, so this feature comes in handy for me. I'm not sure if it's usefull for all use cases.

In summary, it just keeps the numbers of the modifications that are held in vim's undo-tree and uses them to jump around with the `:undo {N}` command.

The commands that call the Submode Undo/Redo functions are:
`:SubmodeUndo`
`:SubmodeRedo`

I also added it in the documentation, along with its limitation and problem.
