### PR TITLE
Added doc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-.vim-flavor
-Gemfile.lock
-VimFlavor.lock
+doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-doc
+doc/tags
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock


### PR DESCRIPTION
doc/tags is needed in .gitignore so that when generating tags it does not show as a change in git.