### PR TITLE
Fix a problem of latest Vim :nnoremap

### DIFF
--- a/autoload/submode.vim
+++ b/autoload/submode.vim
@@ -388,7 +388,11 @@ endfunction
 
 
 function! s:named_key_before_entering_with(submode, lhs)  "{{{2
-  return printf('<Plug>(submode-before-entering:%s:with:%s)', a:submode, a:lhs)
+  return printf(
+  \   '<Plug>(submode-before-entering:%s:with:%s)',
+  \   a:submode,
+  \   substitute(a:lhs, '<\|>', '', 'g')
+  \   )
 endfunction
 
 


### PR DESCRIPTION
# Description

I used below config

```vim
call submode#enter_with('win_resize', 'n', '', '<C-s>w')
call submode#map('win_resize', 'n', '', 'j', '3<C-w>+')
call submode#map('win_resize', 'n', '', 'k', '3<C-w>-')
call submode#map('win_resize', 'n', '', 'h', '3<C-w><')
call submode#map('win_resize', 'n', '', 'l', '3<C-w>>')
call submode#map('win_resize', 'n', '', '<', '20<C-w><')
call submode#map('win_resize', 'n', '', '>', '20<C-w>>')
```

And re-bulid newer Vim, then below error appeared.

```shell-session
$ vim
Error detected while processing function submode#enter_with[3]..<SNR>13_define_entering_mapping:
line   16:
E474: Invalid argument
```

This PR fixes it :+1:

Thanks.